### PR TITLE
feat: Initial packit setup

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,17 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rpm/deepin-desktop-schemas.spec
+
+# add or remove files that should be synced
+synced_files:
+    - rpm/deepin-desktop-schemas.spec
+    - .packit.yaml
+
+upstream_package_name: deepin-desktop-schemas
+# downstream (Fedora) RPM package name
+downstream_package_name: deepin-desktop-schemas
+
+actions:
+  fix-spec-file: |
+    bash -c "sed -i -r \"0,/Version:/ s/Version:(\s*)\S*/Version:\1${PACKIT_PROJECT_VERSION}/\" rpm/deepin-desktop-schemas.spec"

--- a/rpm/deepin-desktop-schemas.spec
+++ b/rpm/deepin-desktop-schemas.spec
@@ -1,16 +1,23 @@
 Name:           deepin-desktop-schemas
-Version:        5.5.0.6
-Release:        1
+Version:        5.8.0.31
+Release:        1%{?dist}
 Summary:        GSettings deepin desktop-wide schemas
 License:        GPLv3
 URL:            https://github.com/linuxdeepin/deepin-desktop-schemas
+%if 0%{?fedora}
+Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
+%else
 Source0:        %{name}_%{version}.orig.tar.xz
+%endif
 
 BuildArch:      noarch
-BuildRequires:  python3 golang-bin
+BuildRequires:  python3
 BuildRequires:  glib2
 #add jzy
-BuildRequires:  go-lib-devel
+BuildRequires:  compiler(go-compiler)
+BuildRequires:  golang(pkg.deepin.io/lib/keyfile)
+ExclusiveArch:  %{go_arches}
+
 Requires:       dconf
 Requires:       deepin-gtk-theme
 Requires:       deepin-icon-theme
@@ -21,7 +28,7 @@ Obsoletes:      deepin-artwork-themes <= 15.12.4
 %{summary}.
 
 %prep
-%setup -q
+%autosetup -p1
 
 # fix default background url
 sed -i '/picture-uri/s|default_background.jpg|default.png|' \
@@ -29,7 +36,7 @@ sed -i '/picture-uri/s|default_background.jpg|default.png|' \
 sed -i 's|python|python3|' Makefile tools/overrides.py
 
 %build
-export GOPATH=/usr/share/gocode
+export GOPATH=%{gopath}
 %make_build ARCH=x86
 
 %install
@@ -43,9 +50,9 @@ make test
 %doc README.md
 %license LICENSE
 %{_datadir}/glib-2.0/schemas/*
-/usr/share/deepin-app-store/*
-/usr/share/deepin-desktop-schemas/*
-/usr/share/deepin-appstore/*
+%{_datadir}/deepin-appstore/
+%{_datadir}/deepin-app-store/
+%{_datadir}/%{name}/
 
 
 %changelog


### PR DESCRIPTION
This commit contains the specfile for building the official package for Fedora
with a Packit setup.

Ultimately, a unified specfile is targeted for Fedora and any other rpm-based
distributions, e.g. openEuler.

And Packit(https://packit.dev/) is a tool for maintaining specfile within
upstream source. It requires a simple config file(.packit.yaml).

Log: Initial packit setup
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>