### PR TITLE
chore: change shortcut to open dde-clipboard to Meta+V

### DIFF
--- a/schemas/com.deepin.dde.keybinding.system.gschema.xml
+++ b/schemas/com.deepin.dde.keybinding.system.gschema.xml
@@ -92,7 +92,7 @@
 			<description/>
 		</key>
 		<key type="as" name="clipboard">
-			<default><![CDATA[['<Control><Alt>V']]]></default>
+			<default><![CDATA[['<Super>V','<Meta>V']]]></default>
 			<summary>Show clipboard</summary>
 			<description/>
 		</key>


### PR DESCRIPTION
将打开剪切板管理器的快捷键调整到 Meta+V，使从其他系统或平台迁移的用户使用更熟悉的快捷键绑定，且避免和其它工具产生快捷键冲突。

Issue: https://github.com/linuxdeepin/developer-center/issues/4597
Log: 将打开剪切板管理器的快捷键调整到 Meta+V