### PR TITLE
chore: release 6.0.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-desktop-schemas (6.0.3) unstable; urgency=medium
+
+  * Ensure REUSE compliance
+  * Add go mod support
+  * Change shortcut to open dde-clipboard to Meta+V
+
+ -- Wang Zichong <wangzichong@deepin.org>  Wed, 5 Jul 2023 11:02:00 +0800
+
 deepin-desktop-schemas (6.0.2) unstable; urgency=medium
 
   [ TagBuilder ]


### PR DESCRIPTION
发布 6.0.3 版本

  * Ensure REUSE compliance
  * Add go mod support
  * Change shortcut to open dde-clipboard to Meta+V https://github.com/linuxdeepin/developer-center/issues/4597