### PR TITLE
fix: change default icon-theme-name  to `bloom`

### DIFF
--- a/schemas/com.deepin.xsettings.gschema.xml
+++ b/schemas/com.deepin.xsettings.gschema.xml
@@ -9,7 +9,7 @@
       </description>
     </key>
     <key type="s" name="icon-theme-name">
-      <default>'deepin'</default>
+      <default>'bloom'</default>
       <summary>Icon theme</summary>
       <description>
         Icon theme to use for the panel, nautilus etc.


### PR DESCRIPTION
default icon theme name is `bloom`

Issue: https://github.com/linuxdeepin/developer-center/issues/7670