### PR TITLE
fix: 解决切换多屏快捷键不生效的问题

### DIFF
--- a/schemas/com.deepin.dde.keybinding.mediakey.gschema.xml
+++ b/schemas/com.deepin.dde.keybinding.mediakey.gschema.xml
@@ -398,11 +398,6 @@
         <!-- ignore XF86Prev_VMode-->
         <!-- ignore XF86LogWindowTree-->
         <!-- ignore XF86LogGrabInfo-->
-        <key type="as" name="switch-monitors">
-            <default><![CDATA[['<Super>P']]]></default>
-            <summary/>
-            <description/>
-        </key>
         <key type="as" name="capslock">
             <default>['Caps_Lock']</default>
             <summary/>

--- a/schemas/com.deepin.dde.keybinding.system.gschema.xml
+++ b/schemas/com.deepin.dde.keybinding.system.gschema.xml
@@ -6,6 +6,11 @@
 			<summary>Show or hide dde-launcher</summary>
 			<description></description>
 		</key>
+		<key type="as" name="switch-monitors">
+			<default><![CDATA[['<Super>P']]]></default>
+			<summary>allow switch monitors display mode</summary>
+			<description></description>
+		</key>
 		<key type="as" name="terminal">
 			<default><![CDATA[['<Control><Alt>T']]]></default>
 			<summary>Launch default terminal emulator</summary>


### PR DESCRIPTION
uos主线将切换多屏快捷键改成系统快捷键，用户可以修改。v25同步该修改

Log: 解决切换多屏快捷键不生效的问题
pms: BUG-295735