### PR TITLE
fix(debian): remove useless dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: deepin-desktop-schemas
 Section: misc
 Priority: optional
 Maintainer: Deepin Sysdev <sysdev@deepin.com>
-Build-depends: debhelper (>= 9), libglib2.0-bin, deepin-desktop-base | deepin-desktop-server | deepin-desktop-device, 
+Build-depends: debhelper (>= 9), libglib2.0-bin,
  golang-go, golang-github-linuxdeepin-go-lib-dev
 Standards-Version: 3.9.5
 Homepage: https://github.com/linuxdeepin/deepin-desktop-schemas


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove useless build and runtime dependencies from debian/control.