### PR TITLE
feat: remove AI assistant keybindings from system schema

### DIFF
--- a/schemas/com.deepin.dde.keybinding.system.gschema.xml
+++ b/schemas/com.deepin.dde.keybinding.system.gschema.xml
@@ -81,11 +81,6 @@
 			<summary>Turn off the screen</summary>
 			<description/>
 		</key>
-		<key type="as" name="ai-assistant">
-			<default><![CDATA[['<Super>Q']]]></default>
-			<summary>Desktop AI Assistant</summary>
-			<description/>
-		</key>
 		<key type="as" name="text-to-speech">
 			<default><![CDATA[['<Control><Alt>P']]]></default>
 			<summary>Text to speech</summary>
@@ -234,11 +229,6 @@
 		<key type="b" name="terminal-quake">
 			<default>true</default>
 			<summary>enabled/disable terminal-quake</summary>
-			<description></description>
-		</key>
-		<key type="b" name="ai-assistant">
-			<default>true</default>
-			<summary>enabled/disable ai-assistant</summary>
 			<description></description>
 		</key>
 		<key type="b" name="wm-switcher">


### PR DESCRIPTION
Removed the AI assistant keybindings from the system gschema, including both the shortcut and the enable/disable toggle options. pms: TASK-369021

## Summary by Sourcery

Enhancements:
- Remove AI assistant shortcut key and enable/disable toggle from system gschema.