### PR TITLE
chore: bump version to 6.0.11

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+deepin-desktop-schemas (6.0.11) unstable; urgency=medium
+
+  * feat: remove AI assistant keybindings from system schema
+  * fix(debian): remove useless dependencies
+  * fix(debian): homepage metadata
+
+ -- fuleyi <fuleyi@uniontech.com>  Wed, 04 Jun 2025 15:41:11 +0800
+
 deepin-desktop-schemas (6.0.10) unstable; urgency=medium
 
   * feat: 触控板自然滚动功能默认开启


### PR DESCRIPTION
update changelog to 6.0.11

## Summary by Sourcery

Chores:
- Bump version to 6.0.11 and update Debian changelog