### PR TITLE
fix: change default value for bluetooth display switch

### DIFF
--- a/schemas/com.deepin.dde.bluetooth.gschema.xml
+++ b/schemas/com.deepin.dde.bluetooth.gschema.xml
@@ -2,7 +2,7 @@
 <schemalist>
     <schema path="/com/deepin/dde/bluetooth/" id="com.deepin.dde.bluetooth">
         <key type="b" name="display-switch">
-            <default>true</default>
+            <default>false</default>
             <summary>Displays Bluetooth devices without a name</summary>
             <description>Displays Bluetooth devices without a name.</description>
         </key>


### PR DESCRIPTION
Changed the default value of 'display-switch' from true to false in Bluetooth schema. This modification ensures that Bluetooth devices without names are not displayed by default, improving user experience by reducing clutter in the device list.

Log: Changed default setting to hide unnamed Bluetooth devices

Influence:
1. Verify Bluetooth device scanning shows only named devices by default
2. Test that unnamed devices can still be displayed when setting is enabled
3. Check if existing user settings override this default value
4. Validate Bluetooth pairing functionality remains unaffected

fix: 修改蓝牙显示开关的默认值

将蓝牙模式中'display-switch'的默认值从true改为false。此修改确保默认情况
下不显示没有名称的蓝牙设备，通过减少设备列表中的杂乱项目来提升用户体验。

Log: 修改默认设置以隐藏未命名的蓝牙设备

Influence:
1. 验证蓝牙设备扫描默认只显示有名称的设备
2. 测试启用设置后仍可显示未命名设备
3. 检查现有用户设置是否会覆盖此默认值
4. 验证蓝牙配对功能不受影响

PMS: BUG-283349

## Summary by Sourcery

Bug Fixes:
- Set default for display-switch to false to prevent unnamed Bluetooth devices from appearing in the device list